### PR TITLE
Fixes #142 (first noticed in #137) and #141

### DIFF
--- a/AEBNiii.bundle/Contents/Code/utils.py
+++ b/AEBNiii.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/AVEntertainments.bundle/Contents/Code/utils.py
+++ b/AVEntertainments.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/BestExclusivePorn.bundle/Contents/Code/utils.py
+++ b/BestExclusivePorn.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)

--- a/CDUniverse.bundle/Contents/Code/utils.py
+++ b/CDUniverse.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/Fagalicious.bundle/Contents/Code/utils.py
+++ b/Fagalicious.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GEVI.bundle/Contents/Code/utils.py
+++ b/GEVI.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayDVDEmpire.bundle/Contents/Code/utils.py
+++ b/GayDVDEmpire.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayFetishandBDSM.bundle/Contents/Code/utils.py
+++ b/GayFetishandBDSM.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayHotMovies.bundle/Contents/Code/utils.py
+++ b/GayHotMovies.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayMovie.bundle/Contents/Code/__init__.py
+++ b/GayMovie.bundle/Contents/Code/__init__.py
@@ -288,7 +288,7 @@ class GayMovie(Agent.Movies):
         # 2a.   Directors
         log(LOG_BIGLINE)
         try:
-            htmldirectors = html.xpath('//div[@class="fusion-text"]/p/descendant::strong[contains(text(),"Director")]/parent::p/strong[last()]/following::text()[normalize-space()]')[0].replace(':', '').split(',')
+            htmldirectors = html.xpath('//strong[text()="Director"]/following::text()[normalize-space()]')[0].replace(':', '').split(',')
             htmldirectors = ['{0}'.format(x.strip()) for x in htmldirectors if x.strip()]
             log('UPDATE:: Director List %s', htmldirectors)
             directorDict = utils.getDirectors(htmldirectors, FILMDICT)
@@ -307,7 +307,7 @@ class GayMovie(Agent.Movies):
         # 2b.   Cast: get thumbnails from IAFD as they are right dimensions for plex cast list
         log(LOG_BIGLINE)
         try:
-            htmlcast = html.xpath('//strong[text()="Actors"]//following::text()[normalize-space()]')[0].replace(':', '').split(',')
+            htmlcast = html.xpath('//strong[text()="Actors"]/following::text()[normalize-space()]')[0].replace(':', '').split(',')
             log('UPDATE:: Cast List %s', htmlcast)
             castDict = utils.getCast(htmlcast, FILMDICT)
 

--- a/GayMovie.bundle/Contents/Code/utils.py
+++ b/GayMovie.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayRado.bundle/Contents/Code/utils.py
+++ b/GayRado.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/GayWorld.bundle/Contents/Code/utils.py
+++ b/GayWorld.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/HFGPM.bundle/Contents/Code/utils.py
+++ b/HFGPM.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/HomoActive.bundle/Contents/Code/utils.py
+++ b/HomoActive.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/IAFD.bundle/Contents/Code/utils.py
+++ b/IAFD.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/QueerClick.bundle/Contents/Code/utils.py
+++ b/QueerClick.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/WayBig.bundle/Contents/Code/utils.py
+++ b/WayBig.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)

--- a/WolffVideo.bundle/Contents/Code/utils.py
+++ b/WolffVideo.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)

--- a/nymMedia.bundle/Contents/Code/utils.py
+++ b/nymMedia.bundle/Contents/Code/utils.py
@@ -22,6 +22,7 @@ General Functions found in all agents
                         - improve REGEX matching on filenames now includes stacking info
                     implemented change by Cody:
                         - duration matching optional on IAFD matching
+    11 Mar 2022     Corrected creation of iafd url string as links now have https:\\iafd.com in them
     
 '''
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -255,7 +256,8 @@ def getFilmOnIAFD(FILMDICT):
             # Film URL
             try:
                 iafdfilmURL = film.xpath('./td[1]/a/@href')[0].replace('+/', '/').replace('-.', '.')
-                iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
+                if IAFD_BASE not in iafdfilmURL:
+                    iafdfilmURL = '{0}{1}'.format(IAFD_BASE, iafdfilmURL) if iafdfilmURL[0] == '/' else '{0}/{1}'.format(IAFD_BASE, iafdfilmURL)
                 log('UTILS :: Site Title url                %s', iafdfilmURL)
                 html = getURLElement(iafdfilmURL, UseAdditionalResults=False)
                 log(LOG_BIGLINE)
@@ -1263,7 +1265,8 @@ def matchTitle(siteTitle, FILMDICT):
         amendedSiteTitle = '{0}{1}'.format(re.sub(pattern, '', amendedSiteTitle).strip(), amendedShortTitle) 
 
     compareSiteTitle = SortAlphaChars(amendedSiteTitle)
-    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Failed'
+    amendedShortTitle = SortAlphaChars(amendedShortTitle)
+    testTitle = 'Passed' if compareSiteTitle in FILMDICT['CompareTitle'] else 'Passed (IAFD)' if compareSiteTitle in FILMDICT['IAFDCompareTitle'] else 'Passed (Amended Title)' if amendedShortTitle in FILMDICT['CompareTitle'] else 'Failed'
 
     log('UTILS :: Site Title                    %s', siteTitle)
     log('UTILS :: Amended Site Title            %s', amendedSiteTitle)


### PR DESCRIPTION
Fixes #142 (first noticed in #137): IAFD made a change to how it handles links; and #141; certain sites without directors return garbage data